### PR TITLE
connection should not be in pool and returned out

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -79,7 +79,8 @@ func (this *ConnectionPool) Get() (net.Conn, error) {
 			}
 
 			this.conns <- conn
-			return this.wrapConn(conn), nil
+			//put connection to pool and go next `for` loop
+			//return this.wrapConn(conn), nil
 		}
 	}
 


### PR DESCRIPTION
如果要放到this.conns中去，就不应该return给外面用，否则岂不是会出现同时被多个地方使用。